### PR TITLE
Исправлено дублирование слэша в поле Area.

### DIFF
--- a/Field/Area/Controller.php
+++ b/Field/Area/Controller.php
@@ -35,6 +35,6 @@ class Controller extends AbstractController
         return
             '<textarea class="form-control" name="' . $this->htmlName
             . '" id="' . $this->htmlName
-            . '">' . htmlspecialchars(str_replace('\\', '\\\\', $this->getValue())) . '</textarea>';
+            . '">' . htmlspecialchars($this->getValue()) . '</textarea>';
     }
 }


### PR DESCRIPTION
Проблема возникала при редактировании регулярных выражений для отсеивания url в html карте сайта .

Пример:
Первоначальный вариант: /error.html
При повторном редактировании: /error\.html
