### PR TITLE
Hotfix/fileCache

### DIFF
--- a/Field/RegexpList/Controller.php
+++ b/Field/RegexpList/Controller.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Ideal CMS (http://idealcms.ru/)
+ *
+ * @link      http://github.com/ideals/idealcms репозиторий исходного кода
+ * @copyright Copyright (c) 2012-2015 Ideal CMS (http://idealcms.ru)
+ * @license   http://idealcms.ru/license.html LGPL v3
+ */
+
+namespace Ideal\Field\RegexpList;
+
+use Ideal\Field\AbstractController;
+
+/**
+ * Отображение редактирования поля в админке в виде textarea
+ *
+ * Пример объявления в конфигурационном файле структуры:
+ *     'exceptions' => array(
+ *         'label' => 'Исключения',
+ *         'sql'   => 'text',
+ *         'type'  => 'Ideal_RegexpList'
+ *     ),
+ */
+class Controller extends AbstractController
+{
+
+    /** {@inheritdoc} */
+    protected static $instance;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getInputText()
+    {
+        return
+            '<textarea class="form-control" name="' . $this->htmlName
+            . '" id="' . $this->htmlName
+            . '">' . htmlspecialchars($this->getValue()) . '</textarea>';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function parseInputValue($isCreate)
+    {
+        $item = parent::parseInputValue($isCreate);
+
+        // Экранируем переводы строки для обработки каждой строки
+        $string = str_replace("\r", '', $this->newValue);
+        $lines = array_filter(explode("\n", $string));
+
+        foreach ($lines as $line) {
+            // Проверка на соответствие формату регулярного выражения, если нет, то уведомляем об этом
+            if (!preg_match("/^\/.*\/[imsxADSUXJu]{0,11}$/", $line)) {
+                $item['message'] = "Строка $line не удовлятворяет формату регулярных выражений.";
+            }
+        }
+
+        return $item;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function pickupNewValue()
+    {
+        // В исключениях не нужны пустые строки
+        $string = str_replace("\r", '', parent::pickupNewValue());
+        $value = implode("\n", array_filter(explode("\n", $string)));
+        return $value;
+    }
+}

--- a/Structure/Service/Cache/AjaxController.php
+++ b/Structure/Service/Cache/AjaxController.php
@@ -11,6 +11,7 @@ namespace Ideal\Structure\Service\Cache;
 use Ideal\Core\FileCache;
 use Ideal\Core\Memcache;
 use Ideal\Core\View;
+use Ideal\Template\SiteMap;
 
 /**
  * Сброс всего кэширования
@@ -45,6 +46,24 @@ class AjaxController extends \Ideal\Core\AjaxController
         }
 
         print json_encode(array('text' => 'ok'));
+        exit;
+    }
+
+    /**
+     * Действие срабатывающее при нажатии на кнопку "Очистить кэш"
+     */
+    public function dellCacheFilesAction()
+    {
+        $delPages = array();
+        $pageList = new SiteMap\Model('0-1');
+        $pages = $pageList->getList();
+        foreach ($pages as $page) {
+            if (FileCache::delCacheFileDir($page['link'])) {
+                $delPages[] = $page['link'];
+            }
+        }
+        $delPages = implode("<br />", $delPages);
+        print json_encode(array('text' => $delPages));
         exit;
     }
 }

--- a/Structure/Service/CheckDb/Action.php
+++ b/Structure/Service/CheckDb/Action.php
@@ -4,6 +4,16 @@ namespace Ideal\Structure\Service\CheckDb;
 use Ideal\Core\Config;
 use Ideal\Core\Db;
 
+echo '<ul class="nav nav-tabs">';
+
+echo '<li class="active"><a href="#bd" data-toggle="tab">База данных</a></li>';
+echo '<li><a href="#cache" data-toggle="tab">Кэш</a></li>';
+
+echo '</ul>';
+echo '<div class="tab-content">';
+
+echo '<div class="tab-pane well active" id="bd">';
+
 echo '<form method="POST" action="">';
 
 $db = Db::getInstance();
@@ -112,7 +122,7 @@ foreach ($dbTables as $table) {
 }
 
 // После нажатия на кнопку применить и совершения действий, нужно либо заново перечитывать БД, либо перегружать страницу
-if (isset($_POST['create']) OR isset($_POST['delete'])) {
+if (isset($_POST['create']) || isset($_POST['delete'])) {
     header('Location: ' . $_SERVER['REQUEST_URI']);
     exit;
 }
@@ -125,3 +135,35 @@ if ($isCool) {
 ?>
 
 </form>
+</div>
+
+<div class="tab-pane well" id="cache">
+    <button class="btn btn-info" value="Удаление файлов" onclick="dellCacheFiles()">
+        Удаление файлов
+    </button>
+</div>
+</div>
+
+
+<script type="application/javascript">
+    function dellCacheFiles()
+    {
+        var text = '';
+        $.ajax({
+            url: 'index.php',
+            data: {action: 'dellCacheFiles', controller: 'Ideal\\Structure\\Service\\Cache', mode: 'ajax'},
+            success: function (data)
+            {
+                if (data.text) {
+                    text = 'Удалённые файлы кэша: <br />' + data.text;
+                }
+                else{
+                    text = 'Информация о закэшированных страницах верна.';
+                }
+                $('.nav-tabs').parent().prepend('<div class="alert alert-block alert-success fade in"> <button type="button" class="close" data-dismiss="alert">&times;</button><span class="alert-heading">' + text + '</span></div>');
+            },
+            type: 'GET',
+            dataType: "json"
+        });
+    }
+</script>

--- a/Structure/Service/CheckDb/config.php
+++ b/Structure/Service/CheckDb/config.php
@@ -1,7 +1,7 @@
 <?php
 
 return array(
-    'name' => 'Проверка целостности базы данных',
+    'name' => 'Проверка целостности',
     'pos' => 30,
     'info' => '',
     'structure' => 'Ideal_Service',

--- a/setup/front/cms/site_data.php
+++ b/setup/front/cms/site_data.php
@@ -23,6 +23,6 @@ return array(
         'memcache' => "0", // Кэширование запросов к БД | Ideal_Checkbox
         'indexFile' => "index.html", // Индексный файл в папке | Ideal_Text
         'fileCache' => "0", // Кэширование страниц в файлы | Ideal_Checkbox
-        'excludeFileCache' => "", // Адреса для исключения из кэша (по одному на строку, формат "регулярные выражения") | Ideal_Area
+        'excludeFileCache' => "", // Адреса для исключения из кэша (по одному на строку, формат "регулярные выражения") | Ideal_RegexpList
     ),
 );

--- a/setup/update/2.1/003_update_site_data.php
+++ b/setup/update/2.1/003_update_site_data.php
@@ -22,7 +22,7 @@ $params['cache']['arr']['fileCache'] = array(
 $params['cache']['arr']['excludeFileCache'] = array(
     'label' => 'Адреса для исключения из кэша (по одному на строку, формат "регулярные выражения")',
     'value' => '',
-    'type' => 'Ideal_Area'
+    'type' => 'Ideal_RegexpList'
 );
 $configSD->setParams($params);
 $configSD->saveFile($file);


### PR DESCRIPTION
Добавлено поле Ideal_RegexpList, для обработки значений регулярных выражений. 
Для адресов вида 'example.com/foo/' создаются индексные файлы с именами, согласно настройке 'Индексный файл в папке'. 
Убрано автоматическое добавление исключений. 
При ручном добавлении исключений добавлена проверка на уже закэшированные исключения.
Уведомление о неправильных regexp'ах теперь быть в стиле 'error'. 
Раздел 'Проверка целостности базы данных' назван 'Проверка целостности' и добавлены вкладки 'База данных' и 'Кэш'. 
Происходит удаление всех закэшированных файлов сайта.