### PR TITLE
FIX: namespace у поля 'Price'

### DIFF
--- a/Field/Price/Controller.php
+++ b/Field/Price/Controller.php
@@ -6,7 +6,7 @@
  * @copyright Copyright (c) 2012-2015 Ideal CMS (http://idealcms.ru)
  * @license   http://idealcms.ru/license.html LGPL v3
  */
-namespace CatalogPlus\Field\Price;
+namespace Ideal\Field\Price;
 
 use Ideal\Core\Request;
 


### PR DESCRIPTION
codesniffer не пропускал с ошибкой 'End of line character is invalid; expected "\n" but found "\r\n"'.
Заменил "\r\n" на "\n", поэтому выделился весь файл. По факту здесь только одно изменение в строке 9.